### PR TITLE
Remove an optional dependency on symfony/intl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "symfony/intl": "~2.5"
+        "php": ">=5.3.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2",


### PR DESCRIPTION
~~Not sure where's this used in the library~~, but the current requirement prevents composer from installing it with Symfony 3.