### PR TITLE
Add intl extension as required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-intl": "*"
     },
     "require-dev": {
         "phpspec/phpspec": "^2",


### PR DESCRIPTION
In order that StringConverter uses NumberFormatter class which requires intl extension