### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,16 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
-    
+
 matrix:
   include:
     - php: 7.0
       env: DEPENDENCIES='low'
     - php: 5.6
     - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
   allow_failures:
     - env: DEPENDENCIES='low'
 
@@ -20,7 +23,7 @@ before_install:
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master
-  - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
+  - if [ "$DEPENDENCIES" != "low" ]; then composer install; fi;
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "coduo/php-to-string",
     "type": "library",
     "keywords": ["string", "php", "to string", "to"],
-    "license": "MIT", 
+    "license": "MIT",
     "authors": [
         {
             "name": "Michał Dąbrowski",
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.6.0",
         "ext-intl": "*"
     },
     "require-dev": {
@@ -22,7 +22,7 @@
         "coduo/phpspec-data-provider-extension": "^1"
     },
     "autoload": {
-        "psr-0": {"" : "src"}
+        "psr-4": {"Coduo\\ToString\\" : "src/Coduo/ToString"}
     },
     "config": {
         "bin-dir": "bin"

--- a/spec/Coduo/ToString/StringConverterSpec.php
+++ b/spec/Coduo/ToString/StringConverterSpec.php
@@ -9,32 +9,32 @@ class StringConverterSpec extends ObjectBehavior
     /**
      * @dataProvider positiveConversionExamples
      */
-    function it_convert_values_to_string($value, $expectedValue)
+    public function it_convert_values_to_string($value, $expectedValue)
     {
         $this->beConstructedWith($value);
         $this->__toString()->shouldReturn($expectedValue);
     }
 
-    function positiveConversionExamples()
+    public function positiveConversionExamples()
     {
-        return array(
-            array(1.1, '1.1'),
-            array(20, '20'),
-            array(true, 'true'),
-            array(new \stdClass(), '\stdClass'),
-            array(new Foo(), 'This is Foo'),
-            array(array('foo', 'bar'), 'Array(2)'),
-            array(function() {return 'test';}, '\Closure')
-        );
+        return [
+            [1.1, '1.1'],
+            [20, '20'],
+            [true, 'true'],
+            [new \stdClass(), '\stdClass'],
+            [new Foo(), 'This is Foo'],
+            [['foo', 'bar'], 'Array(2)'],
+            [function() {return 'test';}, '\Closure'],
+        ];
     }
 
-    function it_convert_double_to_string_for_specific_locale()
+    public function it_convert_double_to_string_for_specific_locale()
     {
         $this->beConstructedWith(1.1, 'pl');
         $this->__toString()->shouldReturn('1,1');
     }
 
-    function it_convert_resource_to_string()
+    public function it_convert_resource_to_string()
     {
         $resource = fopen(sys_get_temp_dir() . "/foo", "w");
         $this->beConstructedWith($resource);


### PR DESCRIPTION
# Changed log
- Since the `php-5.x` is unsupported on PHP team, Let the `php-5.6` version at least.
- Using the `install` option to install dependencies during Travis CI build.
- Using the short array syntax for the `spec` classes.
- The `PSR-0` is deprecated, and using the `PSR-4` autoloading instead.